### PR TITLE
Add annotation tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Annotation tests
+
+Annotations are block comments (`/*^`) that describe how an attribute expands.
+
+Conceptually, `derive_aliases` is a macro that expands to a bunch of `#[derive]` macros.
+We can't use `cargo expand` because that will expand all macros recursively (including the `derive`), so in
+`annotation.rs` there is custom infrastructure to essentially expand the `#[derive_aliases::derive]` macro,
+but not expand the `#[::core::derive]` macros.
+
+The `annotation.rs` runs every file under `tests.rs` and checks that its annotations are correct.
+
+## Example annotation test
+
+```rust
+#[derive_aliases::derive(..Serialize)]
+#[derive_aliases::derive(..Clone)]
+/*^
+$(::core::clone::Clone,)
+@(feature = "serde", $(::serde::Serialize,))
+*/
+struct A {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    field: Option<()>,
+}
+```
+
+The above requires that this:
+
+```rust
+#[derive_aliases::derive(..Serialize)]
+#[cfg_attr(feature = "serde", derive_aliases::derive(..Clone))]
+struct A {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    field: Option<()>,
+}
+```
+
+Will expand into this:
+
+```rust
+#[::core::prelude::v1::derive(::serde::Serialize,)]
+#[cfg_attr(feature = "serde", ::core::prelude::v1::derive(::core::clone::Clone,))]
+struct A {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    field: Option<()>,
+}
+```
+
+## Annotation test syntax
+
+Annotation test comment must start before the item definition, and after
+all attribitues. The annotation test block comment must start with `/*^` instead
+of just `/*`
+
+Additionally:
+
+- Each line in the annotation must be a separate attribute.
+- The `#[` at the start and `]` at the end must not be specified
+- Writing `$` is the same as writing `::core::prelude::v1::derive`
+- Writing `@` is the same as writing `cfg_attr`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +89,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
@@ -58,6 +131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,9 +144,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -75,11 +154,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -89,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -112,9 +190,19 @@ dependencies = [
 name = "derive_aliases"
 version = "0.4.9"
 dependencies = [
+ "annotate-snippets",
+ "anstream",
  "derive_aliases_proc_macro",
+ "evil",
+ "fs-err",
+ "itertools",
+ "monostate",
+ "pretty_assertions",
  "serde",
+ "serde_cursor",
+ "serde_json",
  "serde_with",
+ "tempfile",
  "trybuild",
  "zerocopy",
 ]
@@ -127,10 +215,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -139,16 +239,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "evil"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3936363842224c122b28aeebe253a455219e4ce7717cc57ae65796272e50ef41"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "glob"
@@ -164,9 +308,24 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -199,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +393,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,10 +424,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
@@ -257,15 +455,37 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "monostate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4cc965c89dd0615a9e822ff8002f7633d2466143d51bd58693e4b2c75aabad"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f5b99488110875b5904839d396c2cdfaf241ff6622638acb879cc7effad5de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -283,10 +503,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -305,6 +551,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ref-cast"
@@ -327,16 +579,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schemars"
@@ -363,6 +622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +647,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cursor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad767dbbf4de87b9515c18dacf4beed4c1ed437a31aa09721e3607bcc16c9e2e"
+dependencies = [
+ "serde_core",
+ "serde_cursor_impl",
+ "serde_with",
+]
+
+[[package]]
+name = "serde_cursor_impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27ded70a9079d8ac700e376297feaa0eb077bdaee88f10011422536d6fe5bbe"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,15 +679,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -416,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64",
  "chrono",
@@ -435,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -475,6 +760,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -500,15 +798,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -575,6 +873,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +951,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.4",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.4",
+ "semver",
 ]
 
 [[package]]
@@ -703,6 +1071,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.11.4",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.11.4",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.11.4",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,3 +1183,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,14 @@ categories = ["development-tools", "development-tools::procedural-macro-helpers"
 zerocopy = { version = "0.8", features = ["derive"] }
 trybuild = "1.0"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_with = "3.14.1"
+serde_with = "3.18.0"
+evil = "0.2.2"
+tempfile = "3.27.0"
+serde_json = "1.0.149"
+fs-err = "3.3.0"
+serde_cursor = { version = "0.3", features = ["serde_with"] }
+monostate = "1.0"
+itertools = "0.14.0"
+annotate-snippets = "0.12.13"
+anstream = "1.0.0"
+pretty_assertions = "1.4.1"

--- a/tests/annotation.rs
+++ b/tests/annotation.rs
@@ -1,0 +1,371 @@
+//! This tests annotation comments.
+//!
+//! For more information about annotation tests, see `CONTRIBUTING.md`
+
+use std::{
+    ops::Range,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use fs_err as fs;
+use itertools::Itertools;
+use monostate::MustBe;
+use serde_cursor::Cursor;
+
+/// Tests with annotation comments
+const TESTS: &[&str] = &["serial"];
+
+/// A temporary file that exists only for a brief moment in time
+///
+/// We take a test file, add `trace_macros!()` at the top, then compile the file.
+const ANNOTATION_TEMP_FILE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/tmp-annotation.rs");
+
+#[test]
+fn annotation() -> evil::Result {
+    let mut invalid_expansions = Vec::new();
+
+    for test in TESTS {
+        let test_file_path_relative = format!("tests/{test}.rs");
+        let test_file_path = PathBuf::from(format!(
+            "{}/{test_file_path_relative}",
+            env!("CARGO_MANIFEST_DIR")
+        ));
+
+        // Original content of the test file
+        let test_contents = fs::read_to_string(&test_file_path)?;
+
+        // Same test file, with `trace_macros!(true)` embedded
+        let test_contents = inject_trace_macros(&test_contents)?;
+
+        // All the expansion information returned by `trace_macros!`
+        let trace_macro_output = get_trace_macro_output(&test_contents)?;
+
+        for expansion in trace_macro_output {
+            // How many lines there are with attributes in them
+            //
+            // #[derive_aliases::derive(..Serialize)]  <<<<<< this is 2
+            // #[derive_aliases::derive(..Clone)]      <<<<<<
+            // /*^
+            // $(::serde::Serialize,)
+            // $(::core::clone::Clone,)
+            // */
+            // struct A {
+            //
+            // We start with 1 because the line that we started with
+            // is itself an attribute
+            //
+            // #[derive_aliases::derive(..Serialize)]  <<<<<< we start here
+            // #[derive_aliases::derive(..Clone)]
+            // /*^
+            // $(::serde::Serialize,)
+            // $(::core::clone::Clone,)
+            // */
+            // struct A {
+            let mut attribute_line_count = 1;
+
+            let mut annotation = test_contents
+                .lines()
+                // skip to the start of the macro that is being expanded
+                .skip(expansion.line_start)
+                // skip all the attributes of the item
+                //
+                // #[derive_aliases::derive(..Serialize)]  <<<<<< skip
+                // #[derive_aliases::derive(..Clone)]      <<<<<< skip
+                // /*^
+                // $(::serde::Serialize,)
+                // $(::core::clone::Clone,)
+                // */
+                // struct A {
+                .skip_while(|line| {
+                    if line.starts_with('#') {
+                        attribute_line_count += 1;
+                        true
+                    } else {
+                        false
+                    }
+                })
+                .peekable();
+
+            // the annotation comment must be directly after all the attributes
+            //
+            // #[derive_aliases::derive(..Serialize)]
+            // #[derive_aliases::derive(..Clone)]
+            // /*^                                         <<<<<< must be exact match
+            // $(::serde::Serialize,)
+            // $(::core::clone::Clone,)
+            // */
+            // struct A {
+            if annotation.peek().is_none_or(|line| *line != "/*^") {
+                continue;
+            }
+
+            // #[derive_aliases::derive(..Serialize)]
+            // #[derive_aliases::derive(..Clone)]
+            // /*^                                         <<<<<< we are here now
+            // $(::serde::Serialize,)
+            // $(::core::clone::Clone,)
+            // */
+            // struct A {
+            let _ = annotation.next().expect("we `continue` if `None`");
+
+            // Contents of the annotation comments itself
+            //
+            // #[derive_aliases::derive(..Serialize)]
+            // #[derive_aliases::derive(..Clone)]
+            // /*^
+            // $(::serde::Serialize,)                       <<<<<<
+            // $(::core::clone::Clone,)                     <<<<<< all of this
+            // */
+            // struct A {
+            let annotation_comment = annotation.take_while(|line| *line != "*/");
+
+            // The expected expansion of the attributes, which is different
+            // from the annotation comment - because we do some processing on the annotation comments
+            let expected_expansion = annotation_comment
+                .map(|line| {
+                    format!("#[{line}]")
+                        .replace("$", "::core::prelude::v1::derive")
+                        .replace("@", "cfg_attr")
+                })
+                .join("\n");
+
+            let expansion_byte_range = {
+                // +1 because line_start is 1-indexed and we convert it into 0-indexed
+                let expansion_start_line = expansion.line_start - 1;
+                line_range_to_byte_range(
+                    &test_contents,
+                    expansion_start_line..expansion_start_line + attribute_line_count,
+                )?
+            };
+
+            // Find the last message that starts with an attribute:
+            //
+            // expanding `Clone! .....
+            // to `Clone! .....
+            // expanding `Clone! .....
+            // to `#
+            //
+            // Once we hit that '#', we have fully expanded all the derive aliases
+            let actual_expansion = expansion
+                .messages
+                .iter()
+                .rev()
+                .find(|message| message.starts_with("to `#"))?
+                .strip_prefix("to `")?;
+
+            // where all the attributes end
+            //
+            // #[derive_aliases::derive(..Serialize)]
+            // #[derive_aliases::derive(..Clone)]
+            // /*^
+            // $(::serde::Serialize,)
+            // $(::core::clone::Clone,)
+            // */
+            // struct A {
+            // ^^^^^^ that would be here
+            let end_of_attributes = actual_expansion
+                .find("struct")
+                .or_else(|| actual_expansion.find("pub"))
+                .or_else(|| actual_expansion.find("union"))
+                .or_else(|| actual_expansion.find("enum"))?;
+
+            let actual_expansion = &actual_expansion[..end_of_attributes]
+                .lines()
+                .map(|line| line.split_whitespace().join(""))
+                .join("\n");
+
+            if *actual_expansion == expected_expansion {
+                continue;
+            }
+
+            invalid_expansions.push(InvalidExpansion {
+                span: expansion_byte_range,
+                actual: actual_expansion.to_string(),
+                file: test_contents.clone(),
+                expected: expected_expansion,
+                path: test_file_path_relative.clone().into(),
+            });
+        }
+    }
+
+    for invalid_expansion in &invalid_expansions {
+        invalid_expansion.print();
+    }
+
+    if !invalid_expansions.is_empty() {
+        panic!();
+    }
+
+    evil::Ok(())
+}
+
+/// Converts the given range of lines to a byte range in the given `file`
+fn line_range_to_byte_range(file: &str, line_range: Range<usize>) -> evil::Result<Range<usize>> {
+    let mut line_indices = file
+        .char_indices()
+        .flat_map(|(i, ch)| (ch == '\n').then_some(i))
+        // skipping `line_range.start` lines will exclude the line that we are
+        // actually interested in
+        //
+        // #[derive_aliases::derive(..Serialize)] <<<<<< this line is "line_start.start"
+        // #[derive_aliases::derive(..Clone)]
+        // /*^
+        // $(::serde::Serialize,)
+        // $(::core::clone::Clone,)
+        // */
+        //
+        // We also take +1 more than how many attributes there are. If there are 2 lines with attributes,
+        // we will need to take 3 line endings because:
+        //
+        // ^-------- we want this line ending
+        // #[derive_aliases::derive(..Serialize)]
+        //                                       ^------ and this line ending
+        // #[derive_aliases::derive(..Clone)]
+        //                                   ^------ and this line ending
+        //
+        .skip(line_range.start - 1)
+        .take(line_range.len() + 1);
+
+    let end_of_line_before_start_line = line_indices.next()?;
+    let last_line_byte_start = line_indices.last()?;
+
+    // +1 because we want the start to be directly after the very first line ending
+    //
+    // ^-------- 1st line ending
+    // #[derive_aliases::derive(..Serialize)]
+    // #[derive_aliases::derive(..Clone)]
+    //                                   ^------ last line ending
+    //
+    // #[derive_aliases::derive(..Serialize)]
+    // ^-------- but we actually want to start here (+1 byte)
+    // #[derive_aliases::derive(..Clone)]
+    //                                   ^------ last line ending
+    evil::Ok(end_of_line_before_start_line + 1..last_line_byte_start)
+}
+
+/// Receives contents of a `.rs` file as an input, and compiles that
+/// as a test, returning the compiler messages returned.
+fn get_trace_macro_output(test_contents: &str) -> evil::Result<Vec<ExpansionMacroTrace>> {
+    fs::write(ANNOTATION_TEMP_FILE, test_contents)?;
+
+    let output = Command::new(env!("CARGO"))
+        .arg("check")
+        .arg("--test")
+        .arg("tmp-annotation")
+        .arg("--message-format")
+        .arg("json")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    fs::remove_file(ANNOTATION_TEMP_FILE)?;
+
+    let json = serde_json::Deserializer::from_slice(&output.stdout)
+        .into_iter::<serde_json::Value>()
+        .flatten();
+
+    let expansions =
+        json.flat_map(|value| ExpansionMacroTrace::from_json_slice(&serde_json::to_vec(&value)?));
+
+    evil::Ok(expansions.collect())
+}
+
+/// Adds `trace_macros!(true)` at the start of the file, so we
+/// can collect macro output
+fn inject_trace_macros(contents: &str) -> evil::Result<String> {
+    let lines: Vec<_> = contents.lines().collect();
+
+    let start = lines.iter().enumerate().find_map(|(i, line)| {
+        (!line.starts_with("#![") && !line.starts_with("//!")).then_some(i)
+    })?;
+
+    let (inner_attrs, source) = lines.split_at(start);
+    let inner_attrs = inner_attrs.join("\n");
+    let source = source.join("\n");
+
+    // We very purposefully place trace_macros in such a way that no newlines are created,
+    // to not mess up any line numbers when rendering the diagnostic messages
+
+    evil::Ok(format!(
+        "\
+{inner_attrs} #![feature(trace_macros)] trace_macros!(true);
+{source}"
+    ))
+}
+
+struct ExpansionMacroTrace {
+    /// Compiler messages
+    messages: Vec<String>,
+    /// Line start of the derive macro expansion
+    line_start: usize,
+}
+
+impl ExpansionMacroTrace {
+    fn from_json_slice(value: &[u8]) -> serde_json::Result<Self> {
+        macro_rules! get {
+            ($($cursor:tt)*) => {
+                serde_json::from_slice::<Cursor!($($cursor)*)>(value).map(|it| it.0)
+            };
+        }
+
+        get!(reason: MustBe!("compiler-message"))?;
+        get!(message.message: MustBe!("trace_macro"))?;
+
+        Ok(ExpansionMacroTrace {
+            messages: get!(message.children.*.message)?,
+            line_start: get!(message.spans.0.line_start)?,
+        })
+    }
+}
+
+struct InvalidExpansion {
+    /// The expansion that we expected
+    expected: String,
+    /// The expansion that we actually got
+    actual: String,
+    /// Points to the first invocation of the derive macro
+    /// leading up to the expansion
+    span: Range<usize>,
+    /// The file in which the error originated
+    file: String,
+    /// Path to the file in which the invalid expansion occurred
+    path: PathBuf,
+}
+impl InvalidExpansion {
+    /// Prints the formatted diagnostic about the invalid macro expansion
+    fn print(&self) {
+        let element = annotate_snippets::Snippet::source(&self.file)
+            .line_start(1)
+            .path(format!("{}", self.path.display()))
+            .annotation(
+                annotate_snippets::AnnotationKind::Primary
+                    .span(self.span.clone())
+                    .label("these attributes expand incorrectly"),
+            );
+
+        let report = &[
+            annotate_snippets::Level::ERROR
+                .primary_title("attributes expanded incorrectly")
+                .element(element)
+                .element(annotate_snippets::Padding)
+                .element(annotate_snippets::Padding),
+            annotate_snippets::Group::with_title(
+                annotate_snippets::level::HELP
+                    .primary_title(format!("expected expansion:\n\n{}\n", self.expected)),
+            ),
+            annotate_snippets::Group::with_title(
+                annotate_snippets::level::HELP
+                    .primary_title(format!("actual expansion:\n\n{}", self.actual)),
+            ),
+        ];
+
+        let renderer = annotate_snippets::Renderer::styled()
+            .decor_style(annotate_snippets::renderer::DecorStyle::Unicode);
+        anstream::println!("{}", renderer.render(report));
+        println!(
+            "\n{}",
+            pretty_assertions::StrComparison::new(&self.expected, &self.actual)
+        );
+    }
+}

--- a/tests/serial.rs
+++ b/tests/serial.rs
@@ -13,6 +13,10 @@ mod derive_alias {
 
 #[derive_aliases::derive(..Serialize)]
 #[derive_aliases::derive(..Clone)]
+/*^
+$(::serde::Serialize,)
+$(::core::clone::Clone,)
+*/
 struct A {
     #[serde(skip_serializing_if = "Option::is_none")]
     field: Option<()>,
@@ -20,6 +24,10 @@ struct A {
 
 #[derive_aliases::derive(..Clone)]
 #[derive_aliases::derive(..Serialize)]
+/*^
+$(::core::clone::Clone,)
+$(::serde::Serialize,)
+*/
 struct B {
     #[serde(skip_serializing_if = "Option::is_none")]
     field: Option<()>,
@@ -28,6 +36,10 @@ struct B {
 #[serde_with::skip_serializing_none]
 #[derive_aliases::derive(..Clone)]
 #[derive_aliases::derive(..Serialize)]
+/*^
+$(::core::clone::Clone,)
+$(::serde::Serialize,)
+*/
 struct C {
     field: Option<()>,
 }


### PR DESCRIPTION
These tests are needed to both increase my confidence in the library, and also are a pre-requisite for https://github.com/nik-rev/derive-aliases/pull/7

```rust
#[derive_aliases::derive(..Serialize)]
#[derive_aliases::derive(..Clone)]
/*^
#[::core::derive(::serde::Serialize,)]
#[::core::derive(::core::clone::Clone,)]
*/
struct A {
    #[serde(skip_serializing_if = "Option::is_none")]
    field: Option<()>,
}
```

These annotation tests basically check that the `#[derive_aliases::derive]` invocation expands to what we expect it to expand to.